### PR TITLE
Implement runtime lifecycle controller for ClayEngine::Run()

### DIFF
--- a/ClayEngineLibrary/ClayEngine.h
+++ b/ClayEngineLibrary/ClayEngine.h
@@ -8,7 +8,10 @@
 /******************************************************************************/
 
 #include <Windows.h>
+#include <atomic>
+#include <condition_variable>
 #include <memory>
+#include <mutex>
 
 #include "Strings.h" // String and error handling
 #include "Storage.h" // Filesystem and JSON parsing
@@ -38,18 +41,19 @@ namespace ClayEngine
 		ServerMap m_servers = {};
 		HeadlessMap m_headless = {};
 
+		std::atomic_bool m_shutdown_requested = false;
+		std::mutex m_lifecycle_mutex;
+		std::condition_variable m_lifecycle_cv;
+
+		void ShutdownContexts();
+
 	public:
 		ClayEngine(HINSTANCE hInstance, LPWSTR lpCmdLine, UINT nCmdShow, Locale pLocale);
 		~ClayEngine();
 
-		void Run()
-		{
-			while (!m_clients.empty() || !m_servers.empty() || !m_headless.empty())
-			{
-				bool unreferencedParameter = false;
-				UNREFERENCED_PARAMETER(unreferencedParameter);
-			}
-		}
+		void RequestShutdown();
+
+		void Run();
 	};
 	using ClayEnginePtr = std::unique_ptr<ClayEngine>;
 


### PR DESCRIPTION
## Summary
- replaced the `ClayEngine::Run()` busy-spin loop with a lifecycle wait using `std::condition_variable`
- added explicit shutdown signaling via new `ClayEngine::RequestShutdown()`
- implemented centralized graceful shutdown sequence in `ShutdownContexts()` that destroys headless/server/client contexts in existing order (signaling their thread futures via context destructors)
- updated `ClayEngine` destructor to request shutdown and reuse the same centralized context shutdown path

## Scope adherence
- preserved existing startup/context creation logic in `ClayEngine` constructor
- did not modify DX11/rendering code
- did not touch `JsonFile` logic
- did not change any context constructors
- focused only on `Run()` lifecycle and shutdown mechanism

## Files changed
- `ClayEngineLibrary/ClayEngine.h`
- `ClayEngineLibrary/ClayEngine.cpp`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991f77ee38883259747dcbc4e6aaab7)